### PR TITLE
Change version command to use compile time values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,9 +419,11 @@ version = "0.0.1"
 dependencies = [
  "chrono",
  "dotenv 0.15.0",
+ "git-testament",
  "humantime",
  "itertools",
  "lastfm-rs",
+ "lazy_static",
  "log 0.4.8",
  "pretty_env_logger",
  "reqwest 0.9.24",
@@ -641,6 +643,27 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "git-testament"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef4008ae8759f8f634e9b4db201b2205cbc9992fc36fdacb54a9a7dbd045207"
+dependencies = [
+ "git-testament-derive",
+]
+
+[[package]]
+name = "git-testament-derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4262cd02031d4ce8dad7069232c2cfce38ff9f8557647ea96d130a99f2aa543"
+dependencies = [
+ "chrono",
+ "log 0.4.8",
+ "quote 1.0.2",
+ "syn 1.0.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.1"
 authors = ["Kamran Mackey <kamranm1200@gmail.com>"]
 edition = "2018"
 
+build = "build.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -19,3 +21,6 @@ log = "0.4"
 pretty_env_logger = "0.3"
 rspotify = { git = "https://github.com/KamranMackey/rspotify" }
 lastfm-rs = { git = "https://github.com/KamranMackey/lastfm-rs" }
+git-testament = "0.1"
+lazy_static = "1"
+

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+use std::env;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rustc-env=RUSTC_VERSION={}", rustc_version());
+}
+
+fn rustc_version() -> String {
+    // Compiler used by Cargo.
+    let rustc = env::var_os("RUSTC").expect("missing RUSTC environment variable");
+
+    // `rustc --version` output.
+    let cmd = Command::new(rustc).arg("--version").output().expect("failed to get rust version");
+
+    String::from_utf8_lossy(&cmd.stdout).to_string()
+}
+

--- a/src/commands/utils/version.rs
+++ b/src/commands/utils/version.rs
@@ -1,39 +1,31 @@
+use git_testament::{git_testament, render_testament};
+use lazy_static::lazy_static;
 use serenity::client::Context;
 use serenity::framework::standard::macros::command;
 use serenity::framework::standard::CommandResult;
 use serenity::model::prelude::Message;
 
-use std::process::Command;
+git_testament!(TESTAMENT);
+
+fn version_info() -> &'static str {
+    lazy_static! {
+        static ref RENDERED: String = render_testament!(TESTAMENT, "rust_rewrite");
+    }
+    &RENDERED
+}
 
 #[command]
-#[description("Retrieves the bot version, as well as the underlying Rust / Cargo versions.")]
+#[description("Retrieves the bot version, as well as the underlying rustc version.")]
 #[usage("<blank>")]
 pub fn version(ctx: &mut Context, message: &Message) -> CommandResult {
-    let bot_version = env!("CARGO_PKG_VERSION");
+    let bot_version = version_info();
+    let rustc_version = env!("RUSTC_VERSION");
 
-    let rust_version = if cfg!(target_os = "windows") {
-        Command::new("cmd").arg("/C rustc -V").output().expect("failed to get rust version")
-    } else {
-        Command::new("sh").arg("rustc -V").output().expect("failed to get rust version")
-    };
-
-    let cargo_version = if cfg!(target_os = "windows") {
-        Command::new("cmd").arg("/C cargo -V").output().expect("failed to get cargo version")
-    } else {
-        Command::new("sh").arg("cargo -V").output().expect("failed to get cargo version")
-    };
-
-    let _ = message.channel_id.say(
-        &ctx,
-        format!(
-            "**Version:**: {}\n\
-            **Rust:** {}\
-            **Cargo:** {}",
-            bot_version,
-            String::from_utf8_lossy(&rust_version.stdout),
-            String::from_utf8_lossy(&cargo_version.stdout)
-        ),
-    );
+    let _ = message.channel_id.send_message(&ctx, |m| {
+        m.embed(|e| {
+            e.description(format_args!("**Bot Version**: {}\n**Rust Version**: {}", bot_version, rustc_version))
+        })
+    });
 
     Ok(())
 }


### PR DESCRIPTION
Change the version command to use values obtained at compile time (Fixes #151).

This compiles and should work, however I don't have the environment set up to test it.

Before accepting this PR, I suggest you pull the code and test it locally to check if it's satisfactory.

### Notes

The `git-testament` library relies on building against a git tag or a trusted branch.

To build against a tag:
- Create your tag `git tag "X.X.X" -m "Release version X.X.X"`
- Clean your build cache of the local package `cargo clean -p ellie`
- Cargo build `cargo build --release`

Since there are currently no git tags (as of making this PR), the version will show as `unknown (...)` with the git commit and other info.